### PR TITLE
add support for mvn package assembly:single

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,32 @@
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>3.0.0</version>
         </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>3.1.1</version>
+
+            <configuration>
+                <descriptorRefs>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+                <archive>
+                    <manifest>
+                        <mainClass>hw.Main</mainClass>
+                    </manifest>
+                </archive>
+            </configuration>
+
+            <executions>
+                <execution>
+                    <id>make-assembly</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>single</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
       <version>4.4</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.4</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/hw/Main.java
+++ b/src/main/java/hw/Main.java
@@ -4,6 +4,7 @@ import java.util.Queue;
 // see https://stackoverflow.com/questions/1963806/#21699069
 // why we're using this implementation instead of java.util.ArrayQueue!
 import org.apache.commons.collections4.queue.CircularFifoQueue;
+import org.apache.commons.cli.*;
 import java.util.Scanner;
 import sun.misc.Signal;
 
@@ -14,24 +15,23 @@ public class Main {
   public static void main(final String[] args) {
 
     // TODO consider using a command-line option library
-
-    // perform argument validity checking
-    if (args.length > 1) {
-      System.err.println("usage: ./target/universal/stage/bin/consoleapp [ last_n_words ]");
-      System.exit(2);
-    }
-
+    // TODO this shows how to do it; still need to add help
+    // TODO consider wrapping this in a static method similar to scopt approach: MyConfig getCommandLine(MyConfig defaults)
+    Options options = new Options();
+    Option lastnOpt = Option.builder("lastn").hasArg().build();
+    lastnOpt.setType(Number.class);
+    options.addOption(lastnOpt);
+    CommandLineParser parser = new DefaultParser();
     int lastNWords = LAST_N_WORDS;
     try {
-      if (args.length == 1) {
-        lastNWords = Integer.parseInt(args[0]);
-        if (lastNWords < 1) {
-          throw new NumberFormatException();
-        }
+      CommandLine cmd = parser.parse( options, args);
+      Number lastn = (Number)cmd.getParsedOptionValue("lastn"); 
+      if (lastn != null) {
+        lastNWords = lastn.intValue();
       }
-    } catch (final NumberFormatException ex) {
-      System.err.println("argument should be a natural number");
-      System.exit(4);
+    } catch (final ParseException pe) {
+      System.err.println("Could not parse command line.");
+      System.exit(1);
     }
 
     // properly terminate on SIGPIPE received from downstream


### PR DESCRIPTION
Added support for Maven assembly with dependencies. This is well-supported by Maven community.

To build the assembly with dependencies:

```
mvn package assembly:single
```

We can make things a bit more project specific but this should give us a proper executable .jar file. I was able to confirm that it builds correctly. I've also added `hw.Main` to the manifest.